### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,195 +1,113 @@
-# Run Selenium Tests With WebDriverIO 5.6.2 — TestMu AI (Formerly LambdaTest)
-
-![JavaScript](https://user-images.githubusercontent.com/95698164/172134732-2e9c780e-10ac-4956-b366-86ffc25bf070.png)
+# Run Selenium Tests with WebdriverIO on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/webdriverio"><img src="https://img.shields.io/npm/v/webdriverio.svg?style=for-the-badge&labelColor=000000" alt="WebdriverIO version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
-
-*Learn how to use WebDriverIO 5.6.2 framework to configure and run your JavaScript automation testing scripts on the TestMu AI platform*
-
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
-
-## Table Of Contents
-
-* [Pre-requisites](#pre-requisites)
-* [Installing Selenium Dependencies](#installing-selenium-dependencies)
-* [Getting Started](#getting-started)
-* [Execute The Test](#execute-the-test)
-
-## Pre-requisites 
-
-Before getting started with Automated Scripts using Selenium with WebDriverIO 5.6.2 on TestMu AI Automation, you need to:
-
-* The first step is to download and install node.js and node package manager or npm. You should be having nodejs v6 or newer. Click [here](https://nodejs.org/en/) to download.
-* Make sure to use the latest version of JavaScript.
-* Make sure you have WD installed in your system, you can install it using the below command through npm:
-
-`npm install webdriverio`
-
-* Download [Selenium JavaScript bindings](http://www.seleniumhq.org/download/) from the official Selenium website.
-* Once you download the JavaScript bindings, extract the ZIP file which you’ve downloaded. * After extracting the file, you need to add Selenium Java bindings which is a JAR file and all the dependent libraries to your classpath.
-
-## Installing Selenium Dependencies
-
-Next step is to install Selenium dependencies for Node.js using npm. Here’s the command to run:
-
-`npm i selenium-webdriver`
-
-* Download TestMu AI tunnel binary file if you wish to test your locally hosted or privately hosted projects.
-
-> Follow our documentation on TestMu AI tunnel to know it all. OS specific instructions to download and setup tunnel binary can be found at the following links.
- * [Documentation For Windows User](https://www.testmuai.com/support/docs/local-testing-windows/)
- * [Documentation For Mac User](https://www.testmuai.com/support/docs/local-testing-macos/)
- * [Documentation For Linux User](https://www.testmuai.com/support/docs/local-testing-linux/)
-
-> Download the binary file of:
- * [TestMu AI tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
- * [TestMu AI tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
- * [TestMu AI tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 ## Getting Started
 
-Running WebDriverIO 5.6.2 test scripts on TestMu AI [Selenium Grid](https://www.testmuai.com/blog/why-selenium-grid-is-ideal-for-automated-browser-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) is as easy as changing a few lines of code. To start with, you would have to invoke Selenium remote webdriver instead of local browser webdriver. In addition, since we are using remote webdriver, we have to define which browser environment we want to run the test. We do that by passing browser environment details to TestMu AI Selenium Grid via desired capabilities class. You can use [TestMu AI Capabilities Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) to select & pass those browser environment specifications.
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-Let’s check out sample WebDriverIO 5.6.2 framework code running TestMu AI Selenium Grid. This is a simple WebDriverIO 5.6.2 automation script that test a sample to-do list app. The code marks two list items as done, adds a list item and then finally gives the total number of pending items as output.
+With TestMu AI (Formerly LambdaTest), you can run JavaScript WebdriverIO Selenium automation tests across real browsers and operating systems. This sample shows how to configure Node.js + WebdriverIO to run on the TestMu AI cloud.
 
-You can also find this code at our [GitHub repository for WebDriverIO](https://github.com/LambdaTest/webdriverio-selenium) 5.6.2.
-``` js
-var assert = require('assert');
- 
-describe('Lambdatest Demo Test', function() {
-  it('Lambdatest Demo TestCase', function () {
-    browser
-      .url('https://lambdatest.github.io/sample-todo-app/')
-      .click('*[name="li1"]')
-      .click('*[name="li2"]')
-      .setValue('*[id="sampletodotext"]','Lambdatest\n');
-     
-    assert(browser.getTitle().match(/Sample page - lambdatest.com/i));
-  });
-});
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+
+### Prerequisites
+
+- Node.js and npm (latest stable)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
+
+### Setup
+
+Clone and install dependencies:
+
+```bash
+git clone https://github.com/LambdaTest/webdriverio-selenium && cd webdriverio-selenium
+npm install
 ```
 
-Below is the config.js file where we will be declaring the desired capabilities.
+Set your credentials as environment variables.
 
-``` js
-user= process.env.LT_USERNAME || "<your username>",
-key= process.env.LT_ACCESS_KEY || "<your accessKey>",
- 
-exports.config = {
- 
-  updateJob: false,
-  user,
-  key,
-  specs: [
-    './tests/specs/single_test.js'
-  ],
-  exclude: [],
- 
-  capabilities: [{
-    browserName: 'chrome',
-    version:"64.0",
-    name:"Test webdriverio",
-    build:"build 1",
-  }],
-  sync: true,
-  logLevel: 'info',
-  coloredLogs: true,
-  screenshotPath: './errorShots/',
-  baseUrl: '',
-  waitforTimeout: 100000,
-  connectionRetryTimeout: 90000,
-  connectionRetryCount: 1,
-  path: '/wd/hub',
-  hostname: 'hub.lambdatest.com',
-  port: 80,
- 
-  framework: 'mocha',
-  mochaOpts: {
-      ui: 'bdd'
-  }
-}
+**macOS / Linux:**
+
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+export LT_TUNNEL="YOUR_TUNNEL_NAME"
 ```
 
-The Selenium WebDriver test would open a URL, mark the first two items in the list as done, add an item in the list, and return the total number of pending item. Your results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [TestMu AI dashboard](https://accounts.lambdatest.com/dashboard/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium). TestMu AI dashboard will help you view all your text logs, screenshots and video recording for your entire Selenium tests.
+**Windows:**
 
-## Execute The Test
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+set LT_TUNNEL="YOUR_TUNNEL_NAME"
+```
 
-You would need to execute the below command in your terminal/cmd.
+### Run tests
 
-`npm run single`
+```bash
+npm run single
+```
 
-## Tutorials 📙
+View results on your TestMu AI dashboard.
 
-Check out our latest tutorials on TestNG automation testing 👇
+### Local testing with TestMu AI Tunnel
 
-* [How To Generate HTML Reports With WebdriverIO?](https://www.testmuai.com/blog/webdriverio-html-reporter/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [How To Use Deep Selectors In Selenium WebdriverIO](https://www.testmuai.com/blog/deep-selectors-in-selenium-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [Cross Browser Testing With WebDriverIO [Tutorial]](https://www.testmuai.com/blog/webdriverio-tutorial-with-examples-for-cross-browser-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [How To Speed Up JavaScript Testing With Selenium and WebDriverIO?](https://www.testmuai.com/blog/speed-up-javascript-testing-with-selenium-and-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebDriverIO Tutorial: Handling Alerts & Overlay In Selenium](https://www.testmuai.com/blog/webdriverio-tutorial-handling-alerts-overlay-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebdriverIO Tutorial: Run Your First Automation Script](https://www.testmuai.com/blog/webdriverio-tutorial-run-your-first-automation-script/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebDriverIO Tutorial For Handling Dropdown In Selenium](https://www.testmuai.com/blog/webdriverio-tutorial-for-handling-dropdown-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebdriverIO Tutorial: Browser Commands for Selenium Testing](https://www.testmuai.com/blog/webdriverio-tutorial-browser-commands-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [Automated Monkey Testing with Selenium & WebDriverIO (Examples)](https://www.testmuai.com/blog/monkey-testing-with-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [Selenium WebdriverIO Tutorial](https://www.testmuai.com/blog/webdriverio-tutorial-with-examples-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [How To Use Strings In JavaScript With Selenium WebDriver?](https://www.testmuai.com/blog/using-strings-in-javascript-using-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-## Documentation & Resources :books:
- 
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)    
+Add the following to your capabilities:
 
-## TestMu AI Community :busts_in_silhouette:
+```js
+tunnel: true,
+```
 
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+## Contributions
 
-## What's New At TestMu AI ❓
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and WebdriverIO version.
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
+## TestMu AI (Formerly LambdaTest) Community
 
-## 🚀 LambdaTest is Now TestMu AI
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-### 🔄 Our Rebrand Journey
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
 
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+### How LambdaTest Evolved into TestMu AI
 
-### 🔭 Explore TestMu AI
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -171,13 +171,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -175,11 +175,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Run Selenium Tests With WebDriverIO 5.6.2 On LambdaTest
+# Run Selenium Tests With WebDriverIO 5.6.2 — TestMu AI (Formerly LambdaTest)
 
 ![JavaScript](https://user-images.githubusercontent.com/95698164/172134732-2e9c780e-10ac-4956-b366-86ffc25bf070.png)
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to use WebDriverIO 5.6.2 framework to configure and run your JavaScript automation testing scripts on the LambdaTest platform*
+*Learn how to use WebDriverIO 5.6.2 framework to configure and run your JavaScript automation testing scripts on the TestMu AI platform*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
 
@@ -32,7 +32,7 @@
 
 ## Pre-requisites 
 
-Before getting started with Automated Scripts using Selenium with WebDriverIO 5.6.2 on LambdaTest Automation, you need to:
+Before getting started with Automated Scripts using Selenium with WebDriverIO 5.6.2 on TestMu AI Automation, you need to:
 
 * The first step is to download and install node.js and node package manager or npm. You should be having nodejs v6 or newer. Click [here](https://nodejs.org/en/) to download.
 * Make sure to use the latest version of JavaScript.
@@ -49,23 +49,23 @@ Next step is to install Selenium dependencies for Node.js using npm. Here’s th
 
 `npm i selenium-webdriver`
 
-* Download LambdaTest tunnel binary file if you wish to test your locally hosted or privately hosted projects.
+* Download TestMu AI tunnel binary file if you wish to test your locally hosted or privately hosted projects.
 
-> Follow our documentation on LambdaTest tunnel to know it all. OS specific instructions to download and setup tunnel binary can be found at the following links.
- * [Documentation For Windows User](https://www.lambdatest.com/support/docs/local-testing-windows/)
- * [Documentation For Mac User](https://www.lambdatest.com/support/docs/local-testing-macos/)
- * [Documentation For Linux User](https://www.lambdatest.com/support/docs/local-testing-linux/)
+> Follow our documentation on TestMu AI tunnel to know it all. OS specific instructions to download and setup tunnel binary can be found at the following links.
+ * [Documentation For Windows User](https://www.testmuai.com/support/docs/local-testing-windows/)
+ * [Documentation For Mac User](https://www.testmuai.com/support/docs/local-testing-macos/)
+ * [Documentation For Linux User](https://www.testmuai.com/support/docs/local-testing-linux/)
 
 > Download the binary file of:
- * [LambdaTest tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
- * [LambdaTest tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
- * [LambdaTest tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+ * [TestMu AI tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
+ * [TestMu AI tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
+ * [TestMu AI tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 ## Getting Started
 
-Running WebDriverIO 5.6.2 test scripts on LambdaTest [Selenium Grid](https://www.lambdatest.com/blog/why-selenium-grid-is-ideal-for-automated-browser-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) is as easy as changing a few lines of code. To start with, you would have to invoke Selenium remote webdriver instead of local browser webdriver. In addition, since we are using remote webdriver, we have to define which browser environment we want to run the test. We do that by passing browser environment details to LambdaTest Selenium Grid via desired capabilities class. You can use [LambdaTest Capabilities Generator](https://www.lambdatest.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) to select & pass those browser environment specifications.
+Running WebDriverIO 5.6.2 test scripts on TestMu AI [Selenium Grid](https://www.testmuai.com/blog/why-selenium-grid-is-ideal-for-automated-browser-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) is as easy as changing a few lines of code. To start with, you would have to invoke Selenium remote webdriver instead of local browser webdriver. In addition, since we are using remote webdriver, we have to define which browser environment we want to run the test. We do that by passing browser environment details to TestMu AI Selenium Grid via desired capabilities class. You can use [TestMu AI Capabilities Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) to select & pass those browser environment specifications.
 
-Let’s check out sample WebDriverIO 5.6.2 framework code running LambdaTest Selenium Grid. This is a simple WebDriverIO 5.6.2 automation script that test a sample to-do list app. The code marks two list items as done, adds a list item and then finally gives the total number of pending items as output.
+Let’s check out sample WebDriverIO 5.6.2 framework code running TestMu AI Selenium Grid. This is a simple WebDriverIO 5.6.2 automation script that test a sample to-do list app. The code marks two list items as done, adds a list item and then finally gives the total number of pending items as output.
 
 You can also find this code at our [GitHub repository for WebDriverIO](https://github.com/LambdaTest/webdriverio-selenium) 5.6.2.
 ``` js
@@ -125,7 +125,7 @@ exports.config = {
 }
 ```
 
-The Selenium WebDriver test would open a URL, mark the first two items in the list as done, add an item in the list, and return the total number of pending item. Your results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [LambdaTest dashboard](https://accounts.lambdatest.com/dashboard/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium). LambdaTest dashboard will help you view all your text logs, screenshots and video recording for your entire Selenium tests.
+The Selenium WebDriver test would open a URL, mark the first two items in the list as done, add an item in the list, and return the total number of pending item. Your results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [TestMu AI dashboard](https://accounts.lambdatest.com/dashboard/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium). TestMu AI dashboard will help you view all your text logs, screenshots and video recording for your entire Selenium tests.
 
 ## Execute The Test
 
@@ -137,57 +137,49 @@ You would need to execute the below command in your terminal/cmd.
 
 Check out our latest tutorials on TestNG automation testing 👇
 
-* [How To Generate HTML Reports With WebdriverIO?](https://www.lambdatest.com/blog/webdriverio-html-reporter/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [How To Use Deep Selectors In Selenium WebdriverIO](https://www.lambdatest.com/blog/deep-selectors-in-selenium-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [Cross Browser Testing With WebDriverIO [Tutorial]](https://www.lambdatest.com/blog/webdriverio-tutorial-with-examples-for-cross-browser-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [How To Speed Up JavaScript Testing With Selenium and WebDriverIO?](https://www.lambdatest.com/blog/speed-up-javascript-testing-with-selenium-and-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebDriverIO Tutorial: Handling Alerts & Overlay In Selenium](https://www.lambdatest.com/blog/webdriverio-tutorial-handling-alerts-overlay-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebdriverIO Tutorial: Run Your First Automation Script](https://www.lambdatest.com/blog/webdriverio-tutorial-run-your-first-automation-script/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebDriverIO Tutorial For Handling Dropdown In Selenium](https://www.lambdatest.com/blog/webdriverio-tutorial-for-handling-dropdown-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [WebdriverIO Tutorial: Browser Commands for Selenium Testing](https://www.lambdatest.com/blog/webdriverio-tutorial-browser-commands-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [Automated Monkey Testing with Selenium & WebDriverIO (Examples)](https://www.lambdatest.com/blog/monkey-testing-with-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [Selenium WebdriverIO Tutorial](https://www.lambdatest.com/blog/webdriverio-tutorial-with-examples-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [How To Use Strings In JavaScript With Selenium WebDriver?](https://www.lambdatest.com/blog/using-strings-in-javascript-using-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [How To Generate HTML Reports With WebdriverIO?](https://www.testmuai.com/blog/webdriverio-html-reporter/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [How To Use Deep Selectors In Selenium WebdriverIO](https://www.testmuai.com/blog/deep-selectors-in-selenium-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [Cross Browser Testing With WebDriverIO [Tutorial]](https://www.testmuai.com/blog/webdriverio-tutorial-with-examples-for-cross-browser-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [How To Speed Up JavaScript Testing With Selenium and WebDriverIO?](https://www.testmuai.com/blog/speed-up-javascript-testing-with-selenium-and-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [WebDriverIO Tutorial: Handling Alerts & Overlay In Selenium](https://www.testmuai.com/blog/webdriverio-tutorial-handling-alerts-overlay-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [WebdriverIO Tutorial: Run Your First Automation Script](https://www.testmuai.com/blog/webdriverio-tutorial-run-your-first-automation-script/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [WebDriverIO Tutorial For Handling Dropdown In Selenium](https://www.testmuai.com/blog/webdriverio-tutorial-for-handling-dropdown-in-selenium/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [WebdriverIO Tutorial: Browser Commands for Selenium Testing](https://www.testmuai.com/blog/webdriverio-tutorial-browser-commands-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [Automated Monkey Testing with Selenium & WebDriverIO (Examples)](https://www.testmuai.com/blog/monkey-testing-with-webdriverio/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [Selenium WebdriverIO Tutorial](https://www.testmuai.com/blog/webdriverio-tutorial-with-examples-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [How To Use Strings In JavaScript With Selenium WebDriver?](https://www.testmuai.com/blog/using-strings-in-javascript-using-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
 
 ## Documentation & Resources :books:
  
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)    
 
-## LambdaTest Community :busts_in_silhouette:
+## TestMu AI Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-## What's New At LambdaTest ❓
+## What's New At TestMu AI ❓
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
-      
-## About LambdaTest
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium) is a leading AI-powered test orchestration and execution platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
-      
-## We are here to help you :headphones:
+**🔄 Our Rebrand Journey**
 
-* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=webdriverio-selenium)
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code